### PR TITLE
Add script to check reclient works

### DIFF
--- a/check_reclient_works.py
+++ b/check_reclient_works.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 Contributors to the reclient-configs project. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+from configure_reclient import Paths
+
+def main():
+    Paths.init_from_args(parse_args())
+    return check_reclient_works()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--src_dir',
+        help='Chromium src directory.',
+        default=os.getcwd(),
+    )
+    parser.add_argument(
+        '--reclient_cfgs_dir',
+        help=('Path to Chromium reclient_cfgs directory.'),
+        default=Paths.reclient_cfgs_dir,
+    )
+    parser.add_argument(
+        '--reclient_dir',
+        help=('Path to Chromium reclient directory.'),
+        default=Paths.reclient_dir,
+    )
+    return parser.parse_args()
+
+
+DOCKER_IMAGE = 'docker://docker.io/library/debian@sha256:82bab30ed448b8e2509aabe21f40f0607d905b7fd0dec72802627a20274eba55'
+
+def check_reclient_works():
+    print('Starting reproxy')
+    subprocess.check_call([
+        f'{Paths.reclient_dir}/bootstrap',
+        '--cfg',
+        f'{Paths.reclient_cfgs_dir}/reproxy.cfg',
+    ])
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            print('Remotely executing "echo hello > hello"')
+            subprocess.check_call([
+                f'{Paths.reclient_dir}/rewrapper',
+                '--labels=type=tool',
+                f'--platform=container-image={DOCKER_IMAGE},OSFamily=linux',
+                '--output_files=hello',
+                '/bin/bash', '-c', 'echo hello > hello',
+            ], cwd=tmp_dir)
+            with open(f'{tmp_dir}/hello') as f:
+                result = f.read()
+                if result == 'hello\n':
+                    print('Received expected result')
+                else:
+                    print(f'Received unexpected result: "{result}"')
+                    return 1
+        return 0
+    finally:
+        print('Shutting down reproxy')
+        subprocess.check_call([
+            f'{Paths.reclient_dir}/bootstrap',
+            '--cfg',
+            f'{Paths.reclient_cfgs_dir}/reproxy.cfg',
+            '--shutdown',
+        ])
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/check_reclient_works.py
+++ b/check_reclient_works.py
@@ -14,12 +14,15 @@
 # limitations under the License.
 
 import argparse
-import os
 import subprocess
 import sys
 import tempfile
 
 from configure_reclient import Paths
+
+
+DOCKER_IMAGE = 'docker://docker.io/library/debian@sha256:82bab30ed448b8e2509aabe21f40f0607d905b7fd0dec72802627a20274eba55'
+
 
 def main():
     Paths.init_from_args(parse_args())
@@ -32,7 +35,8 @@ def parse_args():
     parser.add_argument(
         '--src_dir',
         help='Chromium src directory.',
-        default=os.getcwd(),
+        required=True,
+        default=argparse.SUPPRESS,
     )
     parser.add_argument(
         '--reclient_cfgs_dir',
@@ -46,8 +50,6 @@ def parse_args():
     )
     return parser.parse_args()
 
-
-DOCKER_IMAGE = 'docker://docker.io/library/debian@sha256:82bab30ed448b8e2509aabe21f40f0607d905b7fd0dec72802627a20274eba55'
 
 def check_reclient_works():
     print('Starting reproxy')

--- a/configure_reclient.py
+++ b/configure_reclient.py
@@ -275,6 +275,7 @@ class Paths:
     exec_root = '{src_dir}'
     build_dir = '{src_dir}/out/a'
     reclient_cfgs_dir = '{src_dir}/buildtools/reclient_cfgs'
+    reclient_dir = '{src_dir}/buildtools/reclient'
     clang_base_path = '{src_dir}/third_party/llvm-build/Release+Asserts'
     linux_clang_base_path = '{clang_base_path}_linux'
 
@@ -287,20 +288,19 @@ class Paths:
         cls.script_dir = cls.create_path(os.path.dirname(__file__),
                                          'script_dir')
         cls.src_dir = cls.create_path(args.src_dir, 'src_dir')
-        cls.exec_root = cls.create_path(args.exec_root or cls.exec_root,
-                                        'exec_root')
-        cls.build_dir = cls.create_path(args.build_dir or cls.build_dir,
-                                        'build_dir')
-        cls.reclient_cfgs_dir = cls.create_path(
-            args.reclient_cfgs_dir or cls.reclient_cfgs_dir,
-            'reclient_cfgs_dir')
-        cls.clang_base_path = cls.create_path(
-            args.clang_base_path or cls.clang_base_path, 'clang_base_path')
-        cls.linux_clang_base_path = cls.create_path(
-            args.linux_clang_base_path or cls.linux_clang_base_path,
-            'linux_clang_base_path')
+        computed_args = [
+            'exec_root',
+            'build_dir',
+            'reclient_cfgs_dir',
+            'reclient_dir',
+            'clang_base_path',
+            'linux_clang_base_path',
+        ]
+        for arg in computed_args:
+            value = getattr(args, arg) if hasattr(args, arg) else None
+            setattr(cls, arg, cls.create_path(value or getattr(cls, arg), arg))
 
-        if args.custom_py:
+        if hasattr(args, 'custom_py') and args.custom_py:
             cls.custom_py = cls.create_path(args.custom_py, 'custom_py')
 
         # Ensure some dirs are a part of exec_root.


### PR DESCRIPTION
Context: a feature request from Brave, to function similarly to `goma_auth info`. The call to the script can be added to the pipeline setup to make sure Reclient is configured correctly.

I wanted to actually compile a hello-world in C++ using the current Chromium toolchain, but that turned out to be such a PITA that I decided to push it to a followup.