### PR TITLE
Windows: need compiler=clang-cl

### DIFF
--- a/chromium-browser-clang/rewrapper_windows.cfg
+++ b/chromium-browser-clang/rewrapper_windows.cfg
@@ -18,3 +18,4 @@ server_address=pipe://reproxy.pipe
 inputs={src_dir}/buildtools/reclient_cfgs/chromium-browser-clang/clang_remote_wrapper
 toolchain_inputs={linux_clang_base_path}/bin/clang
 remote_wrapper={src_dir}/buildtools/reclient_cfgs/chromium-browser-clang/clang_remote_wrapper
+labels=compiler=clang-cl


### PR DESCRIPTION
We haven't noticed this on later Chromium versions, but e.g. tag `118.0.5993.120` doesn't work without this change.
The current tags work regardless.