### PR TITLE
Remove setting instance by default

### DIFF
--- a/reproxy.cfg
+++ b/reproxy.cfg
@@ -16,4 +16,5 @@
 
 # Unset Chromium variables.
 service=
+instance=
 automatic_auth=


### PR DESCRIPTION
This might get set to `projects/rbe-chrome-untrusted/instances/default_instance` by default and we don't want that.