### PR TITLE
Remove Nacl support

### DIFF
--- a/configure_reclient.py
+++ b/configure_reclient.py
@@ -249,7 +249,7 @@ class ReclientConfigurator:
                                   reproxy_cfg, source_cfg_paths)
 
     def generate_rewrapper_cfgs(self):
-        for tool in ['chromium-browser-clang', 'python', 'nacl']:
+        for tool in ['chromium-browser-clang', 'python']:
             for platform in ['linux', 'mac', 'windows']:
                 self.generate_rewrapper_cfg(tool, platform)
         

--- a/linux/nacl/rewrapper_linux.cfg
+++ b/linux/nacl/rewrapper_linux.cfg
@@ -1,9 +1,0 @@
-platform=container-image=docker://gcr.io/chops-public-images-prod/rbe/siso-chromium/linux@sha256:26de99218a1a8b527d4840490bcbf1690ee0b55c84316300b60776e6b3a03fe1,label:action_default=1
-server_address=unix:///tmp/reproxy.sock
-labels=type=compile,compiler=nacl,lang=cpp
-exec_strategy=remote_local_fallback
-inputs=native_client/toolchain/linux_x86/saigo_newlib/lib
-dial_timeout=10m
-canonicalize_working_dir=true
-exec_timeout=2m
-reclient_timeout=2m


### PR DESCRIPTION
The only place where Google still officially supports Native Client is on ChromeOS.
As such, there's no need to configure nacl for users of this repository.