### PR TITLE
Support specifying the name of the default pool to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,5 +168,10 @@ You can define the name of the large pool by passing the following flag when run
 python3 configure_reclient.py --large_pool_name=<NAME_OF_LARGE_POOL>
 ```
 
-By default, these actions will use the default worker pool, same as other actions. In particular, if
-setting `--default_pool_name`, large actions will also be run on that pool.
+Thus, large actions are run on the following pool:
+
+- If `--large_pool_name` is set, on the pool with the specified name.
+- If `--large_pool_name` is not set and `--default_pool_name` is set, on the pool with the specified
+    name.
+- If neither `--large_pool_name` nor `--default_pool_name` are set, on the remote's default pool,
+    i.e., the pool used when actions do not request being run on a specific pool.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,18 @@ def post_configure():
     pass
 ```
 
-### Define large pool
+### Define pools to run on
+
+#### Define default pool
+
+By default, actions will not specify which pool to run on, so they will be run on the default worker
+pool. You can customize the name of the pool to run actions on as follows:
+
+```
+python3 configure_reclient.py --default_pool_name=<NAME_OF_DEFAULT_POOL>
+```
+
+#### Define large pool
 
 Chromium now supports running actions on a different worker pool that might otherwise run into
 an OOM. See [Reclient](https://source.chromium.org/chromium/chromium/src/+/4f94ce92c8c657cbfeb4dd386581340704c9dd11).
@@ -157,4 +168,5 @@ You can define the name of the large pool by passing the following flag when run
 python3 configure_reclient.py --large_pool_name=<NAME_OF_LARGE_POOL>
 ```
 
-By default, these actions will use the default worker pool, same as other actions.
+By default, these actions will use the default worker pool, same as other actions. In particular, if
+setting `--default_pool_name`, large actions will also be run on that pool.

--- a/configure_reclient.py
+++ b/configure_reclient.py
@@ -93,12 +93,15 @@ def parse_args():
     )
     parser.add_argument(
         '--default_pool_name',
-        help=('The remote pool name to run actions on.'),
+        help=('The remote pool name to run actions on. If unspecified, uses '
+              ' the remote\'s default pool.'),
         default='',
     )
     parser.add_argument(
         '--large_pool_name',
-        help=('The remote pool name to run large actions on.'),
+        help=('The remote pool name to run large actions on. If unspecified, '
+              'uses the pool specified with --default_pool_name, or else the '
+              'remote\'s default pool.'),
         default='',
     )
 

--- a/configure_reclient.py
+++ b/configure_reclient.py
@@ -92,6 +92,11 @@ def parse_args():
         action='store_true',
     )
     parser.add_argument(
+        '--default_pool_name',
+        help=('The remote pool name to run actions on.'),
+        default='',
+    )
+    parser.add_argument(
         '--large_pool_name',
         help=('The remote pool name to run large actions on.'),
         default='',
@@ -270,6 +275,8 @@ class ReclientConfigurator:
             f'{Paths.script_dir}/{tool}/rewrapper_{host_os}.cfg',
         ]
 
+        if self.args.default_pool_name:
+            rewrapper_cfg['platform']['Pool'] = self.args.default_pool_name
         for source_cfg_path in source_cfg_paths:
             rewrapper_cfg = ReclientCfg.merge_cfg(rewrapper_cfg,
                                                   source_cfg_path)
@@ -302,6 +309,8 @@ class ReclientConfigurator:
         ]
         if self.args.large_pool_name:
             rewrapper_cfg['platform']['Pool'] = self.args.large_pool_name
+        elif self.args.default_pool_name:
+            rewrapper_cfg['platform']['Pool'] = self.args.default_pool_name
         for source_cfg_path in source_cfg_paths:
             rewrapper_cfg = ReclientCfg.merge_cfg(rewrapper_cfg,
                                                   source_cfg_path)


### PR DESCRIPTION
Currently, it is only possible to specify the pool name of large actions. With this PR, you can also specify a custom pool name for all actions to be executed on. This is helpful if actions are not to be executed on the RBE service's default pool (used when no pool is specified).