### PR TITLE
Normalize default execution timeout to 10m

### DIFF
--- a/linux/chromium-browser-clang/rewrapper_linux.cfg
+++ b/linux/chromium-browser-clang/rewrapper_linux.cfg
@@ -5,6 +5,6 @@ server_address=unix:///tmp/reproxy.sock
 labels=type=compile,compiler=clang,lang=cpp
 exec_strategy=remote_local_fallback
 dial_timeout=10m
-exec_timeout=2m
-reclient_timeout=2m
+exec_timeout=10m
+reclient_timeout=10m
 canonicalize_working_dir=true

--- a/linux/python/rewrapper_linux.cfg
+++ b/linux/python/rewrapper_linux.cfg
@@ -6,5 +6,5 @@ labels=type=tool
 exec_strategy=remote_local_fallback
 dial_timeout=10m
 canonicalize_working_dir=true
-exec_timeout=2m
-reclient_timeout=2m
+exec_timeout=10m
+reclient_timeout=10m

--- a/linux/python/rewrapper_linux_large.cfg
+++ b/linux/python/rewrapper_linux_large.cfg
@@ -6,5 +6,5 @@ labels=type=tool
 exec_strategy=remote_local_fallback
 dial_timeout=10m
 canonicalize_working_dir=true
-exec_timeout=2m
-reclient_timeout=2m
+exec_timeout=10m
+reclient_timeout=10m


### PR DESCRIPTION
A 2 minute timeout is often not enough if there is too much load or simply if the server is scaled down and needs to scale up before executing actions. `siso` tends to make this worse as it will try to queue more actions remotely after the 2 minute timeout causing even more load on the cluster.